### PR TITLE
feat: add schema for multi tenancy

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -74,7 +74,7 @@ model Organization {
   updatedAt  DateTime     @updatedAt
 }
 
-enum MembershipRole {
+enum UserRole {
   OWNER
   ADMIN
   TEACHER
@@ -84,8 +84,8 @@ enum MembershipRole {
 }
 
 model Membership {
-  id   Int            @id @default(autoincrement())
-  role MembershipRole @default(MEMBER)
+  id   Int      @id @default(autoincrement())
+  role UserRole @default(MEMBER)
 
   organization   Organization @relation(fields: [organizationId], references: [id])
   organizationId String

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -35,10 +35,9 @@ model Session {
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
-enum UserRole {
-  TEACHER
-  STUDENT
-  GUEST
+// The owners of the SaaS (you) can have a SUPERADMIN role to access all data
+enum GlobalRole {
+  USER
   SUPERADMIN
 }
 
@@ -48,7 +47,7 @@ model User {
   email          String?        @unique
   emailVerified  DateTime?
   image          String?
-  role           UserRole
+  role           GlobalRole     @default(USER)
   accounts       Account[]
   sessions       Session[]
   memberships    Membership[]   @relation("members")
@@ -78,7 +77,10 @@ model Organization {
 enum MembershipRole {
   OWNER
   ADMIN
+  TEACHER
+  STUDENT
   MEMBER
+  GUEST
 }
 
 model Membership {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4,8 +4,8 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
 
@@ -23,6 +23,7 @@ model Account {
   id_token          String? @db.Text
   session_state     String?
   user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
   @@unique([provider, providerAccountId])
 }
 
@@ -34,19 +35,80 @@ model Session {
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
+enum UserRole {
+  TEACHER
+  STUDENT
+  GUEST
+  SUPERADMIN
+}
+
 model User {
-  id            String    @id @default(cuid())
-  name          String?
-  email         String?   @unique
-  emailVerified DateTime?
-  image         String?
-  accounts      Account[]
-  sessions      Session[]
+  id             String         @id @default(cuid())
+  name           String?
+  email          String?        @unique
+  emailVerified  DateTime?
+  image          String?
+  role           UserRole
+  accounts       Account[]
+  sessions       Session[]
+  memberships    Membership[]   @relation("members")
+  invitedMembers Membership[]   @relation("inviter")
+  organizations  Organization[]
 }
 
 model VerificationToken {
   identifier String
   token      String   @unique
   expires    DateTime
+
   @@unique([identifier, token])
+}
+
+model Organization {
+  id         String       @id @default(cuid())
+  name       String
+  slug       String
+  creatorId  String
+  creator    User         @relation(fields: [creatorId], references: [id], onDelete: Cascade)
+  membership Membership[]
+  createdAt  DateTime     @default(now())
+  updatedAt  DateTime     @updatedAt
+}
+
+enum MembershipRole {
+  OWNER
+  ADMIN
+  MEMBER
+}
+
+model Membership {
+  id   Int            @id @default(autoincrement())
+  role MembershipRole @default(MEMBER)
+
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  organizationId String
+
+  status InvitationStatus @default(PENDING)
+
+  user   User?   @relation(fields: [userId], references: [id], name: "members")
+  userId String?
+
+  inviter   String
+  invitedBy User   @relation(fields: [inviter], references: [id], name: "inviter")
+
+  // When the user joins, we will clear out the name and email and set the user.
+  invitedName  String?
+  invitedEmail String?
+
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  joinedAt  DateTime?
+
+  @@unique([organizationId, invitedEmail])
+}
+
+enum InvitationStatus {
+  ACCEPTED
+  PENDING
+  DECLINED
 }


### PR DESCRIPTION
this PR add multi-tenant to prisma schema  to serve multiple users which are separated through organizations in a single app. based on https://blitzjs.com/docs/multitenancy