### PR TITLE
Fix smooth scroll

### DIFF
--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { MouseEventHandler, useEffect, useState } from 'react';
 import AnimateHeight from 'react-animate-height';
 import { Github, Menu, Twitter } from 'lucide-react';
 import Link from 'next/link';
@@ -18,7 +18,8 @@ export const Navbar = () => {
     }
   }, [isMobile]);
 
-  const smoothScrollToTop = () => {
+  const smoothScrollToTop: MouseEventHandler<HTMLAnchorElement> = (e) => {
+    e.preventDefault();
     window.scrollTo({
       top: 0,
       behavior: 'smooth',
@@ -26,56 +27,67 @@ export const Navbar = () => {
     isMobile && setHeight(0);
   };
 
-  const smoothScrollToId = (id: string) => () => {
-    window.scrollTo({
-      top: (document.getElementById(id)?.offsetTop ?? 0) - 150,
-      behavior: 'smooth',
-    });
-    isMobile && setHeight(0);
-  };
+  const smoothScrollToId =
+    (id: string): MouseEventHandler<HTMLAnchorElement> =>
+    (e) => {
+      e.preventDefault();
+      window.scrollTo({
+        top: (document.getElementById(id)?.offsetTop ?? 0) - 150,
+        behavior: 'smooth',
+      });
+      isMobile && setHeight(0);
+    };
 
   return (
     <nav className="bg-gray-1 dark:bg-graydark-1 container fixed left-1/2 top-0 z-50 -translate-x-1/2 pb-4 pt-4 lg:bg-transparent lg:pb-0 lg:pt-8 lg:dark:bg-transparent">
       <div className="flex flex-wrap items-center justify-between">
-        <button onClick={smoothScrollToTop} className="flex items-center gap-4">
+        <Link
+          href="/"
+          onClick={smoothScrollToTop}
+          className="flex items-center gap-4"
+        >
           <Brand size={35} />
           <span className="font-semibold">Noodle</span>
-        </button>
+        </Link>
 
         <div className="order-3 w-full md:order-1 md:w-auto">
           <AnimateHeight id="example-panel" duration={500} height={height}>
             <ul className="md:border-gray-6 md:dark:border-graydark-6 bg-gray-1 dark:bg-graydark-1 flex flex-col text-sm md:flex-row md:items-center md:rounded-xl md:border">
               <li>
-                <button
+                <Link
+                  href="/"
                   onClick={smoothScrollToTop}
                   className="text-gray-11 dark:text-graydark-11 hover:text-gray-12 dark:hover:text-graydark-12 inline-block pb-3 pt-6 transition-colors md:py-3 md:pl-4 md:pr-6"
                 >
                   Home
-                </button>
+                </Link>
               </li>
               <li>
-                <button
+                <Link
+                  href="/#features"
                   onClick={smoothScrollToId('features')}
                   className="text-gray-11 dark:text-graydark-11 hover:text-gray-12 dark:hover:text-graydark-12 inline-block py-3 transition-colors md:px-6 md:py-3"
                 >
                   Features
-                </button>
+                </Link>
               </li>
               <li>
-                <button
+                <Link
+                  href="/#mission"
                   onClick={smoothScrollToId('mission')}
                   className="text-gray-11 dark:text-graydark-11 hover:text-gray-12 dark:hover:text-graydark-12 inline-block py-3 transition-colors md:px-6 md:py-3"
                 >
                   Mission
-                </button>
+                </Link>
               </li>
               <li>
-                <button
+                <Link
+                  href="/#faq"
                   onClick={smoothScrollToId('faq')}
                   className="text-gray-11 dark:text-graydark-11 hover:text-gray-12 dark:hover:text-graydark-12 inline-block pb-2 pt-3 transition-colors md:py-3 md:pl-6 md:pr-4"
                 >
                   FAQ
-                </button>
+                </Link>
               </li>
               <li>
                 <a

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -18,52 +18,64 @@ export const Navbar = () => {
     }
   }, [isMobile]);
 
+  const smoothScrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+    isMobile && setHeight(0);
+  };
+
+  const smoothScrollToId = (id: string) => () => {
+    window.scrollTo({
+      top: (document.getElementById(id)?.offsetTop ?? 0) - 150,
+      behavior: 'smooth',
+    });
+    isMobile && setHeight(0);
+  };
+
   return (
     <nav className="bg-gray-1 dark:bg-graydark-1 container fixed left-1/2 top-0 z-50 -translate-x-1/2 pb-4 pt-4 lg:bg-transparent lg:pb-0 lg:pt-8 lg:dark:bg-transparent">
       <div className="flex flex-wrap items-center justify-between">
-        <Link href="/" className="flex items-center gap-4">
+        <button onClick={smoothScrollToTop} className="flex items-center gap-4">
           <Brand size={35} />
           <span className="font-semibold">Noodle</span>
-        </Link>
+        </button>
 
         <div className="order-3 w-full md:order-1 md:w-auto">
           <AnimateHeight id="example-panel" duration={500} height={height}>
             <ul className="md:border-gray-6 md:dark:border-graydark-6 bg-gray-1 dark:bg-graydark-1 flex flex-col text-sm md:flex-row md:items-center md:rounded-xl md:border">
               <li>
-                <Link
-                  href="/"
+                <button
+                  onClick={smoothScrollToTop}
                   className="text-gray-11 dark:text-graydark-11 hover:text-gray-12 dark:hover:text-graydark-12 inline-block pb-3 pt-6 transition-colors md:py-3 md:pl-4 md:pr-6"
-                  onClick={() => isMobile && setHeight(0)}
                 >
                   Home
-                </Link>
+                </button>
               </li>
               <li>
-                <Link
-                  href="/#features"
-                  onClick={() => isMobile && setHeight(0)}
+                <button
+                  onClick={smoothScrollToId('features')}
                   className="text-gray-11 dark:text-graydark-11 hover:text-gray-12 dark:hover:text-graydark-12 inline-block py-3 transition-colors md:px-6 md:py-3"
                 >
                   Features
-                </Link>
+                </button>
               </li>
               <li>
-                <Link
-                  href="/#mission"
-                  onClick={() => isMobile && setHeight(0)}
+                <button
+                  onClick={smoothScrollToId('mission')}
                   className="text-gray-11 dark:text-graydark-11 hover:text-gray-12 dark:hover:text-graydark-12 inline-block py-3 transition-colors md:px-6 md:py-3"
                 >
                   Mission
-                </Link>
+                </button>
               </li>
               <li>
-                <Link
-                  href="/#faq"
-                  onClick={() => isMobile && setHeight(0)}
+                <button
+                  onClick={smoothScrollToId('faq')}
                   className="text-gray-11 dark:text-graydark-11 hover:text-gray-12 dark:hover:text-graydark-12 inline-block pb-2 pt-3 transition-colors md:py-3 md:pl-6 md:pr-4"
                 >
                   FAQ
-                </Link>
+                </button>
               </li>
               <li>
                 <a

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -19,7 +19,7 @@ export const Navbar = () => {
   }, [isMobile]);
 
   return (
-    <nav className="bg-gray-1 dark:bg-graydark-1 container fixed left-1/2 top-0 z-50 -translate-x-1/2 pb-4 pt-4 md:pb-0 lg:bg-transparent lg:pt-8 lg:dark:bg-transparent">
+    <nav className="bg-gray-1 dark:bg-graydark-1 container fixed left-1/2 top-0 z-50 -translate-x-1/2 pb-4 pt-4 lg:bg-transparent lg:pb-0 lg:pt-8 lg:dark:bg-transparent">
       <div className="flex flex-wrap items-center justify-between">
         <Link href="/" className="flex items-center gap-4">
           <Brand size={35} />

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import '@/styles/globals.css';
+
 import { Provider as WrapBalancerProvider } from 'react-wrap-balancer';
 import { Analytics } from '@vercel/analytics/react';
 import { SessionProvider } from 'next-auth/react';

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -1,5 +1,4 @@
 import '@/styles/globals.css';
-
 import { Provider as WrapBalancerProvider } from 'react-wrap-balancer';
 import { Analytics } from '@vercel/analytics/react';
 import { SessionProvider } from 'next-auth/react';
@@ -44,9 +43,6 @@ const App = ({ Component, pageProps }: MyAppProps) => {
       <style jsx global>{`
         :root {
           --font-inter: ${inter.variable}, sans-serif;
-        }
-        html {
-          scroll-behavior: smooth;
         }
       `}</style>
     </div>

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -132,6 +132,13 @@ const features: FeatureCardProps[] = [
   },
 ];
 
+const smoothScrollToId = (id: string) => () => {
+  window.scrollTo({
+    top: (document.getElementById(id)?.offsetTop ?? 0) - 150,
+    behavior: 'smooth',
+  });
+};
+
 const Home: NextPage = () => {
   const isMobile = useMediaQuery('(max-width: 768px)');
 
@@ -156,12 +163,12 @@ const Home: NextPage = () => {
           </Balancer>
         </p>
         <div className="flex w-full flex-col items-center gap-4 lg:w-auto lg:flex-row lg:gap-6">
-          <Link
-            href="#features"
+          <button
+            onClick={smoothScrollToId('features')}
             className="bg-gray-4 dark:bg-graydark-4 border-gray-6 dark:border-graydark-6 hover:bg-gray-5 dark:hover:bg-graydark-5 flex w-full items-center justify-center gap-4 rounded-md border px-6 py-3 font-semibold transition-colors lg:w-auto"
           >
             Features <ArrowDown size={20} />
-          </Link>
+          </button>
           <Link
             href="/waitlist"
             className="bg-primary-500 hover:bg-primary-700 text-gray-12 flex w-full items-center justify-center gap-4 rounded-md px-6 py-3 font-semibold transition-colors lg:w-auto"
@@ -248,7 +255,7 @@ const Home: NextPage = () => {
         </p>
       </section>
       <section
-        id="#faq"
+        id="faq"
         className="container mx-auto mt-36 flex flex-col gap-6 lg:mt-56"
       >
         <h1 className="mx-auto max-w-[20ch] text-center text-5xl font-extrabold tracking-tighter md:text-6xl">

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { Balancer } from 'react-wrap-balancer';
-import type { FC, ReactNode } from 'react';
+import type { FC, MouseEventHandler, ReactNode } from 'react';
 import { ArrowDown, ArrowRight, Star } from 'lucide-react';
 import { type NextPage } from 'next';
 import Image from 'next/image';
@@ -132,12 +132,15 @@ const features: FeatureCardProps[] = [
   },
 ];
 
-const smoothScrollToId = (id: string) => () => {
-  window.scrollTo({
-    top: (document.getElementById(id)?.offsetTop ?? 0) - 150,
-    behavior: 'smooth',
-  });
-};
+const smoothScrollToId =
+  (id: string): MouseEventHandler<HTMLAnchorElement> =>
+  (e) => {
+    e.preventDefault();
+    window.scrollTo({
+      top: (document.getElementById(id)?.offsetTop ?? 0) - 150,
+      behavior: 'smooth',
+    });
+  };
 
 const Home: NextPage = () => {
   const isMobile = useMediaQuery('(max-width: 768px)');
@@ -163,12 +166,13 @@ const Home: NextPage = () => {
           </Balancer>
         </p>
         <div className="flex w-full flex-col items-center gap-4 lg:w-auto lg:flex-row lg:gap-6">
-          <button
+          <Link
+            href="/#features"
             onClick={smoothScrollToId('features')}
             className="bg-gray-4 dark:bg-graydark-4 border-gray-6 dark:border-graydark-6 hover:bg-gray-5 dark:hover:bg-graydark-5 flex w-full items-center justify-center gap-4 rounded-md border px-6 py-3 font-semibold transition-colors lg:w-auto"
           >
             Features <ArrowDown size={20} />
-          </button>
+          </Link>
           <Link
             href="/waitlist"
             className="bg-primary-500 hover:bg-primary-700 text-gray-12 flex w-full items-center justify-center gap-4 rounded-md px-6 py-3 font-semibold transition-colors lg:w-auto"

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -7,7 +7,3 @@
     height: -webkit-fill-available;
   }
 }
-
-html {
-  scroll-behavior: smooth;
-}


### PR DESCRIPTION
This fixes smooth scrolling anchor links not working (at least, on the device I tested: Windows 11 + Chromium engine)