### PR TITLE
feat: users invitation

### DIFF
--- a/apps/web/src/components/WaitListInvitationForm.tsx
+++ b/apps/web/src/components/WaitListInvitationForm.tsx
@@ -1,0 +1,59 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { type TRPCErrorResponse } from '@trpc/server/rpc';
+import { z } from 'zod';
+
+import { Button, Form } from '@noodle/ui';
+
+import { api } from '@/utils/api';
+
+const formSchema = z.object({
+  invitationId: z.string(),
+});
+
+export const WaitListInvitationForm = ({
+  invitationId,
+}: {
+  invitationId: string;
+}) => {
+  const utils = api.useContext();
+
+  const { mutateAsync, isLoading } =
+    api.waitlist.sendUserInvidation.useMutation({
+      async onSuccess() {
+        await utils.waitlist.invalidate();
+      },
+    });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      invitationId: invitationId,
+    },
+  });
+
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    // console.log(values);
+    try {
+      await mutateAsync(values);
+    } catch (error: unknown) {
+      const err = error as TRPCErrorResponse['error'];
+      console.log(err);
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
+        <Button
+          type="submit"
+          size="sm"
+          className="inline-flex"
+          variant="secondary"
+        >
+          {isLoading ? 'Sending...' : ' Send Invitation'}
+        </Button>
+      </form>
+    </Form>
+  );
+};

--- a/apps/web/src/components/WaitListInvitationForm.tsx
+++ b/apps/web/src/components/WaitListInvitationForm.tsx
@@ -33,7 +33,6 @@ export const WaitListInvitationForm = ({
   });
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
-    // console.log(values);
     try {
       await mutateAsync(values);
     } catch (error: unknown) {

--- a/apps/web/src/components/WaitListTable.tsx
+++ b/apps/web/src/components/WaitListTable.tsx
@@ -1,0 +1,42 @@
+import { type FC } from 'react';
+
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@noodle/ui';
+
+import { api } from '@/utils/api';
+import { WaitListTableRow } from './WaitListTableRow';
+
+export const WaitListTable: FC = () => {
+  const { data, isLoading } = api.waitlist.getWaitList.useQuery();
+
+  if (isLoading) {
+    return <>Loading</>;
+  }
+
+  return (
+    <div className="overflow-hidden pb-2 ">
+      <Table>
+        <TableCaption>A list of your waitlist invitations.</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>User</TableHead>
+            <TableHead>Reason</TableHead>
+            <TableHead>Invitation Status</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data?.map((item) => {
+            return <WaitListTableRow key={item.id} data={item} />;
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};

--- a/apps/web/src/components/WaitListTableRow.tsx
+++ b/apps/web/src/components/WaitListTableRow.tsx
@@ -1,0 +1,43 @@
+import { Button, TableCell, TableRow } from '@noodle/ui';
+
+import { WaitListInvitationForm } from './WaitListInvitationForm';
+
+type Reason = 'STUDENT' | 'PROJECT' | 'BOTH';
+
+type WaitListRow = {
+  id: string;
+  name: string;
+  email: string;
+  reason: Reason;
+  approved: boolean;
+  invitationSentAt: string | null;
+  createdAt: string;
+};
+
+export const WaitListTableRow = ({ data }: { data: WaitListRow }) => {
+  return (
+    <TableRow>
+      <TableCell className="font-medium">
+        <span>{data.name}</span>
+        <span className="text-secondary-foreground bg-primary-500/50 ml-2 inline-flex items-center rounded-full border border-transparent px-2.5 py-0.5 text-xs font-semibold transition-colors">
+          {data.email}
+        </span>
+      </TableCell>
+      <TableCell>
+        <span className="text-sm">{data.reason}</span>
+      </TableCell>
+      <TableCell>
+        {data.invitationSentAt ? (
+          <span className="text-sm">Invited</span>
+        ) : (
+          <span className="text-sm">No invitation sent</span>
+        )}
+      </TableCell>
+      <TableCell className="text-right">
+        {!data.invitationSentAt && (
+          <WaitListInvitationForm invitationId={data.id} />
+        )}
+      </TableCell>
+    </TableRow>
+  );
+};

--- a/apps/web/src/pages/app/waitlist.tsx
+++ b/apps/web/src/pages/app/waitlist.tsx
@@ -1,0 +1,33 @@
+import { useUser } from '@clerk/nextjs';
+import router from 'next/router';
+
+import { DashboardPanel } from '@/components/DashboardPanel';
+import { WaitListTable } from '@/components/WaitListTable';
+import { DashboardLayout } from '@/layouts/dashboard';
+import { type NextPageWithLayout } from '@/utils/NextPageWithLayout';
+
+const WaitListPage: NextPageWithLayout = () => {
+  const { user, isLoaded } = useUser();
+  const userMetadata = user?.publicMetadata;
+
+  if (!isLoaded) {
+    return <></>;
+  }
+
+  if (userMetadata?.['role'] !== 'ADMIN') {
+    void router.push('/app');
+  }
+
+  return (
+    <main className="grid h-full w-full grid-cols-[1fr_300px] gap-8 pt-4">
+      <div className="flex flex-col gap-6 overflow-hidden pb-2">
+        <WaitListTable />
+      </div>
+      <DashboardPanel />
+    </main>
+  );
+};
+
+WaitListPage.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default WaitListPage;

--- a/packages/db/drizzle/0002_tan_mulholland_black.sql
+++ b/packages/db/drizzle/0002_tan_mulholland_black.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "WaitingList" ADD COLUMN "invitationSentAt" timestamp(3);

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,131 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "0225a64d-982c-4a37-b5a6-bb8eb3d79fcd",
+  "prevId": "92256758-5450-47a1-a87f-3424a7f92fd6",
+  "tables": {
+    "Feedback": {
+      "name": "Feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "WaitingList": {
+      "name": "WaitingList",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "WaitingListReason",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved": {
+          "name": "approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invitationSentAt": {
+          "name": "invitationSentAt",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "WaitingList_email_key": {
+          "name": "WaitingList_email_key",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "WaitingList_email_unique": {
+          "name": "WaitingList_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "WaitingListReason": {
+      "name": "WaitingListReason",
+      "values": {
+        "STUDENT": "STUDENT",
+        "PROJECT": "PROJECT",
+        "BOTH": "BOTH"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1691160742724,
       "tag": "0001_modern_silk_fever",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1693555299302,
+      "tag": "0002_tan_mulholland_black",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/waiting-list.ts
+++ b/packages/db/src/schema/waiting-list.ts
@@ -26,6 +26,10 @@ export const waitingListTable = pgTable(
     email: text('email').notNull().unique(),
     reason: waitingListReason('reason').notNull(),
     approved: boolean('approved').notNull().default(false),
+    invitationSentAt: timestamp('invitationSentAt', {
+      precision: 3,
+      mode: 'string',
+    }),
     createdAt: timestamp('createdAt', { precision: 3, mode: 'string' })
       .defaultNow()
       .notNull(),

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,3 +12,4 @@ export * from './textarea';
 export * from './form';
 export * from './error-panel';
 export * from './scroll-area';
+export * from './table';

--- a/packages/ui/src/table.tsx
+++ b/packages/ui/src/table.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+
+import { cn } from '@noodle/utils';
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn('w-full caption-bottom text-sm', className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn('[&_tr:last-child]:border-0', className)}
+    {...props}
+  />
+));
+TableBody.displayName = 'TableBody';
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn('bg-primary text-primary-foreground font-medium', className)}
+    {...props}
+  />
+));
+TableFooter.displayName = 'TableFooter';
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+      className,
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'text-muted-foreground h-12 px-4 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0',
+      className,
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    {...props}
+  />
+));
+TableCell.displayName = 'TableCell';
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn('text-muted-foreground mt-4 text-sm', className)}
+    {...props}
+  />
+));
+TableCaption.displayName = 'TableCaption';
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};


### PR DESCRIPTION
This pr introduced users invitation to noodle
I created a page `app/waitlist` to display all users invitations
As `admin` you need to add `{ "role": "ADMIN" }` as public metadata to your user from clerk dashboard 
After that go to `User & Authentication` -> `Restrictions` in clerk dashboard, enable `allowlist` and add your user to `Identifiers`
You can visit `app/waitlist` only if you have `{ "role": "ADMIN" }` in as user
When you visit `app/waitlist` you will be able to send invitations to your users by clicking `Send Invitation` button
`Send Invitation` action add the user email to Allowlist Identifiers and sends a invitation email to the user